### PR TITLE
Adds a missing dependency for json_pure

### DIFF
--- a/mockserver-client.gemspec
+++ b/mockserver-client.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'hashie', '~> 3.0'
   spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'json_pure', '~> 1.8'
   spec.add_dependency 'activesupport', '~> 4.1'
   spec.add_dependency 'rest-client', '~> 1.7'
   spec.add_dependency 'logging_factory', '~> 0.0.2'


### PR DESCRIPTION
This PR cherry-pick's an [upstream fix](https://github.com/jamesdbloom/mockserver/commit/00615e649878c1db502b99399be8e43a365f019b#diff-a92c9207c2bffa90e1c2c59aa958dc1f), adding a missing gem dependency.
